### PR TITLE
Feature: content event types

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,16 @@ A Dart library for discovering and controlling UPnP devices.
 [![codecov](https://codecov.io/gh/huffSamuel/upnped/graph/badge.svg?token=VAFSPLCEQV)](https://codecov.io/gh/huffSamuel/upnped)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
+## Features
+
+This package is implemented around the UPnP 2.0 architecture and supports the following UPnP server features:
+
+- UPnP discovery
+- Device and Service information
+- Non-standard vendor extensions
+- Service control
+- Event monitoring
+
 ## Installation
 
 Install from pub with:
@@ -20,36 +30,28 @@ dependencies:
   upnped: <latest_version>
 ```
 
-## Usage
-
-### Discover devices
+## Quickstart
 
 ```dart
-final server = Server.getInstance();
+import 'package:upnped/upnped.dart';
 
-server.devices.listen((UPnPDevice event) {
-    print('Discovered a device: ${event}');
-});
+Future<void> main() async {
+  final server = Server.getInstance();
 
-await server.listen(Options{
-    locale: 'en',
-});
-await server.search();
+  server.devices.listen((Device event) {
+    print('Discovered a device: ${event});
+  });
+
+  await server.listen(Options());
+  await server.search();
+  await server.stop();
+}
 ```
 
-### Invoke actions
+## Documentation
 
-```dart
-final control = ControlPoint.getInstance();
-UPnPDevice device = getDevice();
-ServiceAction action = selectAction(device);
-Map<String, dynamic> actionArgs = collectArgs();
+Check out the [documentation](https://huffsamuel.github.io/upnped) or [examples](./example).
 
-action.invoke(control, actionArgs);us
-```
+## Contributing
 
-### Monitor UPnP Events
-
-```dart
-UPnPObserver.networkEvents.listen(print);
-```
+Find something that's missing? Feel free to open an [issue](https://github.com/huffSamuel/upnped/issues) or submit a pull request.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A Dart library for discovering and controlling UPnP devices.
 
 ## Features
 
-This package is implemented around the UPnP 2.0 architecture and supports the following UPnP server features:
+This package partially implements UPnP 2.0 architecture and supports the following UPnP server features:
 
 - UPnP discovery
 - Device and Service information
@@ -50,8 +50,8 @@ Future<void> main() async {
 
 ## Documentation
 
-Check out the [documentation](https://huffsamuel.github.io/upnped) or [examples](./example).
+Check out the [documentation](https://huffsamuel.github.io/upnped) or [examples](./example) for more information.
 
 ## Contributing
 
-Find something that's missing? Feel free to open an [issue](https://github.com/huffSamuel/upnped/issues) or submit a pull request.
+Something missing that you need? Open an [issue](https://github.com/huffSamuel/upnped/issues) or submit a pull request.

--- a/example/EXAMPLES.md
+++ b/example/EXAMPLES.md
@@ -1,0 +1,8 @@
+# Examples
+
+- [Quickstart](./quickstart.dart)
+- [Discovery Filter](./discovery_filter.dart)
+- [Device Information](./device_information.dart)
+- [Vendor Extensions](./vendor_extensions.dart)
+- [Service Control](./service_control.dart)
+- [Event Monitoring](./event_monitoring.dart)

--- a/example/device_information.dart
+++ b/example/device_information.dart
@@ -1,0 +1,38 @@
+// ignore_for_file: avoid_print
+
+import 'package:upnped/upnped.dart';
+
+Future<void> main() async {
+  final server = Server.getInstance();
+
+  server.devices.listen((Device event) {
+    var s = StringBuffer('Device Information:')
+      ..writeln('Name: ${event.description.friendlyName}')
+      ..writeln('Manufacturer: ${event.description.manufacturer}')
+      ..writeln('Model: ${event.description.modelName}');
+
+    if (event.description.presentationUrl != null) {
+      s.writeln('Presentation URL: ${event.description.presentationUrl}');
+    }
+
+    s.writeln('Number of services: ${event.services.length}');
+
+    print(s.toString());
+
+    event.isActive.listen((isActive) {
+      var s = StringBuffer('${event.description.friendlyName} is ');
+
+      if (!isActive) {
+        s.write('not ');
+      }
+
+      s.write('active.');
+      
+      print(s.toString());
+    });
+  });
+
+  await server.listen(Options());
+  await server.search();
+  await server.stop();
+}

--- a/example/discovery_filter.dart
+++ b/example/discovery_filter.dart
@@ -1,0 +1,22 @@
+// ignore_for_file: avoid_print
+
+import 'package:upnped/upnped.dart';
+
+Future<void> main() async {
+  final devices = <Device>[];
+  final server = Server.getInstance();
+
+  // Any device that has the same location URI will not be discovered.
+  // The server will receive the NOTIFY event from the device but will not
+  // request any device or service description information.
+  server.loadPredicate =
+      (d) => devices.any((x) => x.notify?.location == d.location);
+
+  server.devices.listen((Device event) {
+    devices.add(event);
+  });
+
+  await server.listen(Options());
+  await server.search();
+  await server.stop();
+}

--- a/example/event_monitoring.dart
+++ b/example/event_monitoring.dart
@@ -1,0 +1,15 @@
+// ignore_for_file: avoid_print
+
+import 'package:upnped/upnped.dart';
+
+Future<void> main() async {
+  final server = Server.getInstance();
+
+  UPnPObserver.networkEvents.listen((NetworkEvent event) {
+    print('${event.type} event: ${event.content}');
+  });
+
+  await server.listen(Options());
+  await server.search();
+  await server.stop();
+}

--- a/example/quickstart.dart
+++ b/example/quickstart.dart
@@ -1,21 +1,15 @@
 // ignore_for_file: avoid_print
+
 import 'package:upnped/upnped.dart';
 
 Future<void> main() async {
   final server = Server.getInstance();
 
   server.devices.listen((Device event) {
-    print('Discovered a device');
-    print(event.description.friendlyName);
-
-    event.services.first.description!.actions.first
-        .invoke({'someArgFromList': 'foo'});
+    print('Discovered a device: $event');
   });
 
-  await server.listen(Options(
-    locale: 'en',
-  ));
-
+  await server.listen(Options());
   await server.search();
   await server.stop();
 }

--- a/example/service_control.dart
+++ b/example/service_control.dart
@@ -1,0 +1,47 @@
+// ignore_for_file: avoid_print
+
+import 'package:upnped/upnped.dart';
+
+Future<void> main() async {
+  final server = Server.getInstance();
+
+  server.devices.listen((Device event) async {
+    final service = event.services[0];
+    final action = service.description!.actions[0];
+
+    final args = _populateActionArgs(action, service);
+
+    try {
+      final response = await action.invoke(args);
+
+      print('Command complete: ${response.arguments}');
+    } on ActionInvocationException catch (e) {
+      print('Something went wrong: $e');
+    }
+  });
+
+  await server.listen(Options());
+  await server.search();
+  await server.stop();
+}
+
+Map<String, dynamic> _populateActionArgs(Action action, Service service) {
+  // Cross reference arguments and state table variables to
+  // get all information about the variable, default values,
+  // data types, etc.
+  final expectedArgs = action.arguments!.map((a) => (
+        a,
+        _relatedStateVariable(service, a.relatedStateVariable),
+      ));
+
+  print(expectedArgs);
+
+  // Some input process here needs to fill out the map of arguments and their values
+
+  return {};
+}
+
+StateVariable _relatedStateVariable(Service service, String variableName) {
+  return service.description!.serviceStateTable.stateVariables
+      .singleWhere((x) => x.name == variableName);
+}

--- a/example/vendor_extensions.dart
+++ b/example/vendor_extensions.dart
@@ -1,0 +1,17 @@
+// ignore_for_file: avoid_print
+
+import 'package:upnped/upnped.dart';
+
+Future<void> main() async {
+  final server = Server.getInstance();
+
+  server.devices.listen((Device event) {
+    if (event.description.extensions.contains('x-my-vendor-extension')) {
+      // Enable some additional feature here.
+    }
+  });
+
+  await server.listen(Options());
+  await server.search();
+  await server.stop();
+}

--- a/lib/src/defaults.dart
+++ b/lib/src/defaults.dart
@@ -11,4 +11,4 @@ const defaultSearchTarget = SearchTarget.rootDevice;
 /// The current system's locale.
 String get defaultLocale => Platform.localeName.substring(0, 2);
 
-const packageVersion = '1.0.0';
+const packageVersion = '1.1.2';

--- a/lib/src/shared/shared.dart
+++ b/lib/src/shared/shared.dart
@@ -28,7 +28,7 @@ class Log {
     String message, [
     Map<String, dynamic>? properties,
   ]) {
-    if (!kDebugMode && !UPnPObserver.loggingEnabled) {
+    if (!(kDebugMode || UPnPObserver.loggingEnabled)) {
       return;
     }
 

--- a/lib/src/ssdp/ssdp_server.dart
+++ b/lib/src/ssdp/ssdp_server.dart
@@ -114,7 +114,8 @@ class Server {
       try {
         socket.send(data, target, _ssdpPort);
 
-        networkController.add(MSearchEvent(request.toString()));
+        final event = MSearchEvent(content: request.toString());
+        networkController.add(event);
       } on SocketException catch (e) {
         Log.error('Unable to send MSEARCH packet', {"exception": e});
       }
@@ -143,7 +144,11 @@ class Server {
       final notify = Notify.parse(data);
 
       final device = NotifyDiscovered(notify);
-      networkController.add(NotifyEvent(device.location!, notify.toString()));
+      final event = NotifyEvent(
+        device.location!,
+        content: notify.toString(),
+      );
+      networkController.add(event);
       _discoveredController.add(notify);
     } catch (err) {
       Log.error('Unable to parse packet as NOTIFY', {

--- a/lib/src/upnp/models/device.dart
+++ b/lib/src/upnp/models/device.dart
@@ -6,10 +6,13 @@ abstract class Device {
 
   /// Emits when the active state of this device changes.
   ///
-  /// Active state can be changed by the following events:
-  /// - Network `ssdp:byebye` event
-  /// - Network `ssdp:alive` event
-  /// - NOTIFY cache-control max-age elapsed
+  /// The device goes inactive when:
+  /// - The device emits an `ssdp:byebye` event
+  /// - The devices NOTIFY cache-control max-age elapses
+  /// 
+  /// The active state is refreshed when:
+  /// - The device emits an `ssdp:alive` event
+  /// - The device emits a NOTIFY event
   Stream<bool> get isActive => _activeController.stream;
 
   /// Notify that replied to the SSDP query.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: upnped
 description: A Dart library for discovering and controlling UPnP devices.
-version: 1.1.1
+version: 1.1.2
 repository: https://github.com/huffSamuel/upnped
 homepage: https://github.com/huffSamuel/upnped
 

--- a/test/shared/network_event_test.dart
+++ b/test/shared/network_event_test.dart
@@ -14,7 +14,7 @@ void main() {
   group('MSearchEvent', () {
     group('constructor', () {
       test('should set the default properties', () {
-        final event = MSearchEvent('content');
+        final event = MSearchEvent(content: 'content');
 
         expect(event.direction, equals(NetworkEventDirection.outgoing));
         expect(event.protocol, equals(NetworkEventProtocol.ssdp));
@@ -26,7 +26,7 @@ void main() {
     group('toString', () {
       test('should return content', () {
         const expected = 'content';
-        final event = MSearchEvent(expected);
+        final event = MSearchEvent(content: expected);
 
         final actual = event.toString();
         expect(actual, equals(expected));
@@ -37,7 +37,7 @@ void main() {
   group('NotifyEvent', () {
     group('constructor', () {
       test('should set the default properties', () {
-        final event = NotifyEvent(Uri(host: 'test.com'), 'content');
+        final event = NotifyEvent(Uri(host: 'test.com'), content: 'content');
 
         expect(event.direction, equals(NetworkEventDirection.incoming));
         expect(event.protocol, NetworkEventProtocol.ssdp);
@@ -49,7 +49,7 @@ void main() {
     group('toString', () {
       test('should return content', () {
         const expected = 'content';
-        final event = NotifyEvent(Uri(host: 'test.com'), 'content');
+        final event = NotifyEvent(Uri(host: 'test.com'), content: 'content');
 
         final actual = event.toString();
         expect(actual, equals(expected));


### PR DESCRIPTION
## What?
Improve the API around event types.

## Why?
This change makes consuming the event types easier by extending the current API to allow easier access to event content without needing to know the specific event type (`HttpEvent` vs `NotifyEvent` vs `MSearchEvent`).

## How?
I moved the `content` property to the base `NetworkEvent` type and use that common property for all derived event types.

## Testing?
Unit tested.

## Screenshots (optional)
N/A.

## Anything Else?
This PR also improves project documentation.

*Based on [Writing A Great Pull Request Description](https://www.pullrequest.com/blog/writing-a-great-pull-request-description/)

BEGIN_COMMIT_OVERRIDE
fix: better network event code
docs: improve API documentatin

END_COMMIT_OVERRIDE